### PR TITLE
Fix total votes scope to remove redundant DB query

### DIFF
--- a/src/Traits/Votable.php
+++ b/src/Traits/Votable.php
@@ -104,17 +104,23 @@ trait Votable
 
     public function scopeWithTotalVotes(Builder $builder): Builder
     {
-        return $builder->withSum('votes as total_votes', 'votes');
+        return $builder->withSum(['votes as total_votes' =>
+            fn ($q) => $q->select(\DB::raw('COALESCE(SUM(votes), 0)'))
+        ], 'votes');
     }
 
     public function scopeWithTotalUpvotes(Builder $builder): Builder
     {
-        return $builder->withSum(['votes as total_upvotes' => fn ($q) => $q->where('votes', '>', 0)], 'votes');
+        return $builder->withSum(['votes as total_upvotes' =>
+            fn ($q) => $q->where('votes', '>', 0)->select(\DB::raw('COALESCE(SUM(votes), 0)'))
+        ], 'votes');
     }
 
     public function scopeWithTotalDownvotes(Builder $builder): Builder
     {
-        return $builder->withSum(['votes as total_downvotes' => fn ($q) => $q->where('votes', '<', 0)], 'votes');
+        return $builder->withSum(['votes as total_downvotes' =>
+            fn ($q) => $q->where('votes', '<', 0)->select(\DB::raw('COALESCE(SUM(votes), 0)'))
+        ], 'votes');
     }
 
     public function scopeWithVotesAttributes(Builder $builder)


### PR DESCRIPTION
If you try to get something like
`Idea::withTotalVotes()->get()`
the attribute `total_votes` can be null if there are no votes, which will result in additional query because of this fallback
https://github.com/overtrue/laravel-vote/blob/f06ad18d7b509cc2f3d507ffb6afd7a0d0e6775b/src/Traits/Votable.php#L77

i suggest to use `COALESCE` to make it zero when no records are found